### PR TITLE
remove localhost server code, use vercel dev for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server/server.js",
   "scripts": {
-    "start": "node server/server.js"
+    "start": "vercel dev"
   },
   "dependencies": {
     "@tailwindcss/cli": "^4.1.6",

--- a/server/server.js
+++ b/server/server.js
@@ -18,7 +18,6 @@ app.get("/api/index", (req, res) => {
     res.json({ message: "Hello from Express on Vercel!" });
 });
 
-app.use(express.static(path.join(__dirname, '..')));
 app.use(( req, res, next ) => {
     console.log('REQ:', req.method, req.url);
     next();
@@ -26,11 +25,5 @@ app.use(( req, res, next ) => {
 app.use('/api/subscribe', subscribeRoute);
 app.use('/api/confirm', confirmRoute);
 app.use('/api/unsubscribe', unsubscribeRoute);
-
-if (require.main === module) {
-    app.listen(3333, () => {
-        console.log('Server is running on http://localhost:3333');
-    });
-}
 
 module.exports = app;


### PR DESCRIPTION
Remove app.listen and express.static — Vercel's runtime handles both (static files via CDN, server lifecycle via serverless functions). Update start script to use vercel dev so local dev mirrors production.