### PR TITLE
fix output directory for Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "outputDirectory": ".",
   "rewrites": [
     { "source": "/api/:path*", "destination": "/api/index.js" }
   ]


### PR DESCRIPTION
Explicitly set outputDirectory to "." so Vercel serves from the project root instead of defaulting to the public/ subdirectory.