### PR TITLE
make site responsive for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,21 +14,29 @@
 
 <body class="h-full bg-gradient-to-b from-lime-700 to-lime-200 text-shadow-lg">
         <header>
-            <h1 class="p-10 text-5xl metamorphous-regular">
-                <a href="index.html">The Lord of the Rats</a>
-            </h1>
-
-            <div class="inline-flex px-25 float-right text-2xl macondo-regular">
-                    <h4 class="px-10"><a href="index.html">Home</a></h4>
-                    <h4 class="px-10"><a href="public/main-pages/about.html">About</a></h4>
-                    <h4 class="px-10"><a href="public/main-pages/gallery.html">Gallery</a></h4>
-                    <h4 class="px-10"><a href="public/main-pages/contact.html">Contact</a></h4>
+            <div class="flex items-center justify-between px-4 md:px-10 py-4">
+                <h1 class="text-3xl md:text-5xl metamorphous-regular">
+                    <a href="/index.html">The Lord of the Rats</a>
+                </h1>
+                <button id="menu-toggle" class="md:hidden text-3xl p-2 leading-none">&#9776;</button>
+                <nav class="hidden md:flex text-2xl macondo-regular">
+                    <h4 class="px-6"><a href="/index.html">Home</a></h4>
+                    <h4 class="px-6"><a href="/public/main-pages/about.html">About</a></h4>
+                    <h4 class="px-6"><a href="/public/main-pages/gallery.html">Gallery</a></h4>
+                    <h4 class="px-6"><a href="/public/main-pages/contact.html">Contact</a></h4>
+                </nav>
             </div>
+            <nav id="mobile-menu" class="hidden flex-col items-center text-xl macondo-regular py-2">
+                <a href="/index.html" class="py-3 w-full text-center">Home</a>
+                <a href="/public/main-pages/about.html" class="py-3 w-full text-center">About</a>
+                <a href="/public/main-pages/gallery.html" class="py-3 w-full text-center">Gallery</a>
+                <a href="/public/main-pages/contact.html" class="py-3 w-full text-center">Contact</a>
+            </nav>
         </header>
 
     <br>
 
-    <div class="inline-flex p-10 text-xl">
+    <div class="flex flex-wrap p-4 md:p-10 text-xl">
         <h5 class="pr-2 pl-10"><a href="public/subpages/cosplay.html"> Cosplayer,</a></h5>
         <h5 class="pr-2"><a href="public/subpages/larp.html">LARPer,</a></h5>
         <h5 class="pr-2"><a href="public/subpages/craft.html">Crafter,</a></h5>
@@ -133,6 +141,13 @@
     </footer>
 
     <script src="public/js/carousel.js"></script>
+    <script>
+        document.getElementById('menu-toggle').addEventListener('click', function() {
+            var menu = document.getElementById('mobile-menu');
+            menu.classList.toggle('hidden');
+            menu.classList.toggle('flex');
+        });
+    </script>
 
 </body>
 </html>

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -26,6 +26,11 @@
   background-color: lightgray;
 }
 
+#name, #email, #subject, #message {
+  width: 100%;
+  max-width: 400px;
+}
+
 #submit {
   padding: 3px 10px 2px 10px;
   border: 2px solid #3B82F6;
@@ -57,8 +62,8 @@
   margin: 0 auto;
   text-align: center;
   position: relative;
-  width: 500px;
-  height: 600px;
+  width: min(500px, 90vw);
+  height: min(600px, 108vw);
   overflow: hidden;
 }
 
@@ -120,4 +125,22 @@ button {
 
 input.invalid, textarea.invalid {
   border-color: darkred;
+}
+
+.youTube-embed {
+  min-height: 220px;
+}
+
+.youTube-embed iframe {
+  min-height: 220px;
+}
+
+@media (max-width: 767px) {
+  .floater {
+    float: none;
+    display: block;
+    margin: 0 auto 1rem;
+    padding-right: 0;
+    text-align: center;
+  }
 }

--- a/public/main-pages/about.html
+++ b/public/main-pages/about.html
@@ -14,16 +14,24 @@
 
 <body class="h-full bg-gradient-to-b from-lime-700 to-lime-200 text-shadow-lg">
     <header>
-            <h1 class="p-10 text-5xl metamorphous-regular">
-                <a href="../../index.html">The Lord of the Rats</a>
-            </h1>
-
-            <div class="inline-flex px-25 float-right text-2xl macondo-regular">
-                    <h4 class="px-10"><a href="../../index.html">Home</a></h4>
-                    <h4 class="px-10"><a href="about.html">About</a></h4>
-                    <h4 class="px-10"><a href="gallery.html">Gallery</a></h4>
-                    <h4 class="px-10"><a href="contact.html">Contact</a></h4>
+            <div class="flex items-center justify-between px-4 md:px-10 py-4">
+                <h1 class="text-3xl md:text-5xl metamorphous-regular">
+                    <a href="/index.html">The Lord of the Rats</a>
+                </h1>
+                <button id="menu-toggle" class="md:hidden text-3xl p-2 leading-none">&#9776;</button>
+                <nav class="hidden md:flex text-2xl macondo-regular">
+                    <h4 class="px-6"><a href="/index.html">Home</a></h4>
+                    <h4 class="px-6"><a href="about.html">About</a></h4>
+                    <h4 class="px-6"><a href="gallery.html">Gallery</a></h4>
+                    <h4 class="px-6"><a href="contact.html">Contact</a></h4>
+                </nav>
             </div>
+            <nav id="mobile-menu" class="hidden flex-col items-center text-xl macondo-regular py-2">
+                <a href="/index.html" class="py-3 w-full text-center">Home</a>
+                <a href="about.html" class="py-3 w-full text-center">About</a>
+                <a href="gallery.html" class="py-3 w-full text-center">Gallery</a>
+                <a href="contact.html" class="py-3 w-full text-center">Contact</a>
+            </nav>
         </header>
 
     <br>
@@ -80,6 +88,12 @@
             </div>
         </div>
     </footer>
-    
+    <script>
+        document.getElementById('menu-toggle').addEventListener('click', function() {
+            var menu = document.getElementById('mobile-menu');
+            menu.classList.toggle('hidden');
+            menu.classList.toggle('flex');
+        });
+    </script>
 </body>
 </html>

--- a/public/main-pages/contact.html
+++ b/public/main-pages/contact.html
@@ -14,50 +14,58 @@
 
 <body class="h-full bg-gradient-to-b from-lime-700 to-lime-200 text-shadow-lg">
     <header>
-            <h1 class="p-10 text-5xl metamorphous-regular">
-                <a href="index.html">The Lord of the Rats</a>
-            </h1>
-
-            <div class="inline-flex px-25 float-right text-2xl macondo-regular">
-                    <h4 class="px-10"><a href="/index.html">Home</a></h4>
-                    <h4 class="px-10"><a href="about.html">About</a></h4>
-                    <h4 class="px-10"><a href="gallery.html">Gallery</a></h4>
-                    <h4 class="px-10"><a href="contact.html">Contact</a></h4>
+            <div class="flex items-center justify-between px-4 md:px-10 py-4">
+                <h1 class="text-3xl md:text-5xl metamorphous-regular">
+                    <a href="/index.html">The Lord of the Rats</a>
+                </h1>
+                <button id="menu-toggle" class="md:hidden text-3xl p-2 leading-none">&#9776;</button>
+                <nav class="hidden md:flex text-2xl macondo-regular">
+                    <h4 class="px-6"><a href="/index.html">Home</a></h4>
+                    <h4 class="px-6"><a href="about.html">About</a></h4>
+                    <h4 class="px-6"><a href="gallery.html">Gallery</a></h4>
+                    <h4 class="px-6"><a href="contact.html">Contact</a></h4>
+                </nav>
             </div>
+            <nav id="mobile-menu" class="hidden flex-col items-center text-xl macondo-regular py-2">
+                <a href="/index.html" class="py-3 w-full text-center">Home</a>
+                <a href="about.html" class="py-3 w-full text-center">About</a>
+                <a href="gallery.html" class="py-3 w-full text-center">Gallery</a>
+                <a href="contact.html" class="py-3 w-full text-center">Contact</a>
+            </nav>
         </header>
 
     <br>
     <br>
     <br>
 
-    <div class="container mx-auto inline-flex">
-        <div class="container px-15 text-xl">
+    <div class="container mx-auto flex flex-col md:flex-row">
+        <div class="px-6 md:px-15 text-xl">
             <form id="contact-form">
                 <label for="name" class="text-2xl metamorphous-regular">Name:</label>
                 <br>
-                <input type="text" id="name" name="name" placeholder="Gaius Fabius Maximus" size="40" class="border-2 border-blue-500 rounded">
+                <input type="text" id="name" name="name" placeholder="Gaius Fabius Maximus" class="border-2 border-blue-500 rounded">
                 <span class="error-message"></span>
                 <br>
                 <label for="email" class="text-2xl metamorphous-regular">Email:</label>
                 <br>
-                <input type="email" id="email" name="email" placeholder="ikickedhannibalsbutt@gmail.com" size="40" class="border-2 border-blue-500 rounded">
+                <input type="email" id="email" name="email" placeholder="ikickedhannibalsbutt@gmail.com" class="border-2 border-blue-500 rounded">
                 <span class="error-message"></span>
                 <br>
                 <label for="subject" class="text-2xl metamorphous-regular">Subject:</label>
                 <br>
-                <input type="text" name="subject" id="subject" placeholder="What's this about?" size="40" class="border-2 border-blue-500 rounded">
+                <input type="text" name="subject" id="subject" placeholder="What's this about?" class="border-2 border-blue-500 rounded">
                 <span class="error-message"></span>
                 <br>
                 <label for="message" class="text-2xl metamorphous-regular">Message:</label>
                 <br>
-                <textarea name="message" id="message" rows="8" cols="43" placeholder="Tell me something I don't know" class="border-2 border-blue-500 rounded"></textarea>
+                <textarea name="message" id="message" rows="8" placeholder="Tell me something I don't know" class="border-2 border-blue-500 rounded"></textarea>
                 <span class="error-message"></span>
                 <br>
-                <input type="submit" value="Submit" id="submit" class="metamorphous-regular" class="border-2 border-blue-500 rounded">
+                <input type="submit" value="Submit" id="submit" class="metamorphous-regular border-2 border-blue-500 rounded">
             </form>
         </div>
 
-        <div class="container px-15">
+        <div class="px-6 md:px-15 mt-8 md:mt-0">
             <h3 class="text-3xl metamorphous-regular">Contact Me</h3>
             <br>
             <br>
@@ -102,6 +110,12 @@
 
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@emailjs/browser@4/dist/email.min.js"></script>
     <script src="../js/contactForm.js"></script>
-    
+    <script>
+        document.getElementById('menu-toggle').addEventListener('click', function() {
+            var menu = document.getElementById('mobile-menu');
+            menu.classList.toggle('hidden');
+            menu.classList.toggle('flex');
+        });
+    </script>
 </body>
 </html>

--- a/public/main-pages/gallery.html
+++ b/public/main-pages/gallery.html
@@ -14,23 +14,31 @@
 
 <body class="h-full bg-gradient-to-b from-lime-700 to-lime-200 text-shadow-lg">
     <header>
-            <h1 class="p-10 text-5xl metamorphous-regular">
-                <a href="index.html">The Lord of the Rats</a>
-            </h1>
-
-            <div class="inline-flex px-25 float-right text-2xl macondo-regular">
-                    <h4 class="px-10"><a href="/index.html">Home</a></h4>
-                    <h4 class="px-10"><a href="about.html">About</a></h4>
-                    <h4 class="px-10"><a href="gallery.html">Gallery</a></h4>
-                    <h4 class="px-10"><a href="contact.html">Contact</a></h4>
+            <div class="flex items-center justify-between px-4 md:px-10 py-4">
+                <h1 class="text-3xl md:text-5xl metamorphous-regular">
+                    <a href="/index.html">The Lord of the Rats</a>
+                </h1>
+                <button id="menu-toggle" class="md:hidden text-3xl p-2 leading-none">&#9776;</button>
+                <nav class="hidden md:flex text-2xl macondo-regular">
+                    <h4 class="px-6"><a href="/index.html">Home</a></h4>
+                    <h4 class="px-6"><a href="about.html">About</a></h4>
+                    <h4 class="px-6"><a href="gallery.html">Gallery</a></h4>
+                    <h4 class="px-6"><a href="contact.html">Contact</a></h4>
+                </nav>
             </div>
+            <nav id="mobile-menu" class="hidden flex-col items-center text-xl macondo-regular py-2">
+                <a href="/index.html" class="py-3 w-full text-center">Home</a>
+                <a href="about.html" class="py-3 w-full text-center">About</a>
+                <a href="gallery.html" class="py-3 w-full text-center">Gallery</a>
+                <a href="contact.html" class="py-3 w-full text-center">Contact</a>
+            </nav>
         </header>
 
     <br>
     <br>
     <br>
 
-    <div class="container flex items-center">
+    <div class="container flex flex-col md:flex-row gap-8 items-start px-4 md:px-0">
         <div class="px-15 instagram-embed">
             <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/the.lord.of.the.rats/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="14" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:100%; min-width:100%; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);">
                 <div style="padding:16px;">
@@ -126,6 +134,12 @@
             </div>
         </div>
     </footer>
-    
+    <script>
+        document.getElementById('menu-toggle').addEventListener('click', function() {
+            var menu = document.getElementById('mobile-menu');
+            menu.classList.toggle('hidden');
+            menu.classList.toggle('flex');
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
- Add hamburger menu to all pages; desktop nav hidden on small screens
- Carousel resizes responsively using min(500px, 90vw) instead of fixed 500px
- Contact form stacks to single column on mobile (flex-col md:flex-row)
- Gallery embeds stack vertically on mobile (flex-col md:flex-row)
- Remove hardcoded size/cols attrs from form inputs; use CSS width instead
- Un-float about page image on mobile so it doesn't crush text
- YouTube embed gets min-height so it renders on mobile