### PR TITLE
Fix hamburger on all pages and h1 tap target

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -86,7 +86,7 @@
   transition: opacity 0.5s ease-in-out;
 }
 
-button {
+#prevBtn, #nextBtn {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -152,11 +152,7 @@ input.invalid, textarea.invalid {
   /* Show the hamburger button */
   #menu-toggle {
     display: block;
-    position: static;
-    top: auto;
-    transform: none;
     background: none;
-    background-color: transparent;
     border: none;
     font-size: 2rem;
     padding: 0.5rem 1rem;

--- a/public/subpages/cosplay.html
+++ b/public/subpages/cosplay.html
@@ -18,13 +18,20 @@
                 <a href="/index.html">The Lord of the Rats</a>
             </h1>
 
-            <div class="inline-flex px-25 float-right text-2xl macondo-regular">
+            <div id="desktop-nav" class="inline-flex px-25 float-right text-2xl macondo-regular">
                     <h4 class="px-10"><a href="/index.html">Home</a></h4>
                     <h4 class="px-10"><a href="../main-pages/about.html">About</a></h4>
                     <h4 class="px-10"><a href="../main-pages/gallery.html">Gallery</a></h4>
                     <h4 class="px-10"><a href="../main-pages/contact.html">Contact</a></h4>
             </div>
+            <button id="menu-toggle" aria-label="Open menu">&#9776;</button>
         </header>
+        <nav id="mobile-menu">
+            <a href="/index.html">Home</a>
+            <a href="../main-pages/about.html">About</a>
+            <a href="../main-pages/gallery.html">Gallery</a>
+            <a href="../main-pages/contact.html">Contact</a>
+        </nav>
 
     <br>
     <br>
@@ -180,5 +187,13 @@
         </div>
     </footer>
 
+    <script>
+        const toggle = document.getElementById('menu-toggle');
+        const mobileMenu = document.getElementById('mobile-menu');
+        toggle.addEventListener('click', () => {
+            const isOpen = mobileMenu.style.display === 'flex';
+            mobileMenu.style.display = isOpen ? 'none' : 'flex';
+        });
+    </script>
 </body>
 </html>

--- a/public/subpages/craft.html
+++ b/public/subpages/craft.html
@@ -18,13 +18,20 @@
                 <a href="/index.html">The Lord of the Rats</a>
             </h1>
 
-            <div class="inline-flex px-25 float-right text-2xl macondo-regular">
+            <div id="desktop-nav" class="inline-flex px-25 float-right text-2xl macondo-regular">
                     <h4 class="px-10"><a href="/index.html">Home</a></h4>
                     <h4 class="px-10"><a href="../main-pages/about.html">About</a></h4>
                     <h4 class="px-10"><a href="../main-pages/gallery.html">Gallery</a></h4>
                     <h4 class="px-10"><a href="../main-pages/contact.html">Contact</a></h4>
             </div>
+            <button id="menu-toggle" aria-label="Open menu">&#9776;</button>
         </header>
+        <nav id="mobile-menu">
+            <a href="/index.html">Home</a>
+            <a href="../main-pages/about.html">About</a>
+            <a href="../main-pages/gallery.html">Gallery</a>
+            <a href="../main-pages/contact.html">Contact</a>
+        </nav>
 
     <br>
     <br>
@@ -117,5 +124,13 @@
         </div>
     </footer>
 
+    <script>
+        const toggle = document.getElementById('menu-toggle');
+        const mobileMenu = document.getElementById('mobile-menu');
+        toggle.addEventListener('click', () => {
+            const isOpen = mobileMenu.style.display === 'flex';
+            mobileMenu.style.display = isOpen ? 'none' : 'flex';
+        });
+    </script>
 </body>
 </html>

--- a/public/subpages/larp.html
+++ b/public/subpages/larp.html
@@ -18,13 +18,20 @@
                 <a href="/index.html">The Lord of the Rats</a>
             </h1>
 
-            <div class="inline-flex px-25 float-right text-2xl macondo-regular">
+            <div id="desktop-nav" class="inline-flex px-25 float-right text-2xl macondo-regular">
                     <h4 class="px-10"><a href="/index.html">Home</a></h4>
                     <h4 class="px-10"><a href="../main-pages/about.html">About</a></h4>
                     <h4 class="px-10"><a href="../main-pages/gallery.html">Gallery</a></h4>
                     <h4 class="px-10"><a href="../main-pages/contact.html">Contact</a></h4>
             </div>
+            <button id="menu-toggle" aria-label="Open menu">&#9776;</button>
         </header>
+        <nav id="mobile-menu">
+            <a href="/index.html">Home</a>
+            <a href="../main-pages/about.html">About</a>
+            <a href="../main-pages/gallery.html">Gallery</a>
+            <a href="../main-pages/contact.html">Contact</a>
+        </nav>
 
     <br>
     <br>
@@ -84,5 +91,13 @@
         </div>
     </footer>
 
+    <script>
+        const toggle = document.getElementById('menu-toggle');
+        const mobileMenu = document.getElementById('mobile-menu');
+        toggle.addEventListener('click', () => {
+            const isOpen = mobileMenu.style.display === 'flex';
+            mobileMenu.style.display = isOpen ? 'none' : 'flex';
+        });
+    </script>
 </body>
 </html>

--- a/public/subpages/writer.html
+++ b/public/subpages/writer.html
@@ -18,13 +18,20 @@
                 <a href="/index.html">The Lord of the Rats</a>
             </h1>
 
-            <div class="inline-flex px-25 float-right text-2xl macondo-regular">
+            <div id="desktop-nav" class="inline-flex px-25 float-right text-2xl macondo-regular">
                     <h4 class="px-10"><a href="/index.html">Home</a></h4>
                     <h4 class="px-10"><a href="../main-pages/about.html">About</a></h4>
                     <h4 class="px-10"><a href="../main-pages/gallery.html">Gallery</a></h4>
                     <h4 class="px-10"><a href="../main-pages/contact.html">Contact</a></h4>
             </div>
+            <button id="menu-toggle" aria-label="Open menu">&#9776;</button>
         </header>
+        <nav id="mobile-menu">
+            <a href="/index.html">Home</a>
+            <a href="../main-pages/about.html">About</a>
+            <a href="../main-pages/gallery.html">Gallery</a>
+            <a href="../main-pages/contact.html">Contact</a>
+        </nav>
 
     <br>
     <br>
@@ -94,5 +101,13 @@
         </div>
     </footer>
 
+    <script>
+        const toggle = document.getElementById('menu-toggle');
+        const mobileMenu = document.getElementById('mobile-menu');
+        toggle.addEventListener('click', () => {
+            const isOpen = mobileMenu.style.display === 'flex';
+            mobileMenu.style.display = isOpen ? 'none' : 'flex';
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Scope the carousel button styles from the global `button` selector to `#prevBtn, #nextBtn` — the old rule was creating an invisible absolutely-positioned overlay that blocked taps on the h1 link. Add the hamburger menu and mobile nav to the four subpages that were missed.