### PR TITLE
Fix broken h1 home link on gallery and contact pages

### DIFF
--- a/public/main-pages/contact.html
+++ b/public/main-pages/contact.html
@@ -15,7 +15,7 @@
 <body class="h-full bg-gradient-to-b from-lime-700 to-lime-200 text-shadow-lg">
     <header>
             <h1 class="p-10 text-5xl metamorphous-regular">
-                <a href="index.html">The Lord of the Rats</a>
+                <a href="/index.html">The Lord of the Rats</a>
             </h1>
 
             <div id="desktop-nav" class="inline-flex px-25 float-right text-2xl macondo-regular">

--- a/public/main-pages/gallery.html
+++ b/public/main-pages/gallery.html
@@ -15,7 +15,7 @@
 <body class="h-full bg-gradient-to-b from-lime-700 to-lime-200 text-shadow-lg">
     <header>
             <h1 class="p-10 text-5xl metamorphous-regular">
-                <a href="index.html">The Lord of the Rats</a>
+                <a href="/index.html">The Lord of the Rats</a>
             </h1>
 
             <div id="desktop-nav" class="inline-flex px-25 float-right text-2xl macondo-regular">


### PR DESCRIPTION
Relative href="index.html" resolved to /public/main-pages/index.html (404). Changed to absolute /index.html.